### PR TITLE
Fix centroid calculation for multi-polygon features

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,8 +288,21 @@
   }
 
   function centroidOfFeature(feat,w,h){
-    let sumX=0,sumY=0,n=0; const g=feat.geometry; const consume=(ring)=>{ ring.forEach(([lon,lat])=>{ const [x,y]=project(lon,lat,w,h); sumX+=x; sumY+=y; n++; }); };
-    if(g.type==='Polygon') consume(g.coordinates[0]); else if(g.type==='MultiPolygon') consume(g.coordinates[0][0]);
+    let sumX=0,sumY=0,n=0; const g=feat.geometry||{};
+    const consumeRing=(ring)=>{
+      if(!Array.isArray(ring)) return;
+      ring.forEach(([lon,lat])=>{
+        const [x,y]=project(lon,lat,w,h);
+        sumX+=x; sumY+=y; n++;
+      });
+    };
+    if(g.type==='Polygon' && Array.isArray(g.coordinates)){
+      g.coordinates.forEach((ring,idx)=>{ if(idx===0) consumeRing(ring); });
+    } else if(g.type==='MultiPolygon' && Array.isArray(g.coordinates)){
+      g.coordinates.forEach(poly=>{
+        if(Array.isArray(poly) && poly.length>0) consumeRing(poly[0]);
+      });
+    }
     if(n===0) return [w/2,h/2]; return [sumX/n, sumY/n];
   }
 


### PR DESCRIPTION
## Summary
- update centroid calculation to include all outer rings in polygon and multi-polygon features
- ensure centroid averaging reflects total coordinates gathered across outer rings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dbdd1f113483259e0dd0d7e15d6006