### PR TITLE
Adapt local JSON ingestion to new analytics export schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -497,7 +497,9 @@
     countryDetail:{ code:null, name:'', cities:[] }, // GEO cities | TOP recent videos
     timeseries:[],
     topAllTime:[],                // prepared rows for TOP mode
-    mostWatchedRecent: null       // {title, videoId, viewsInRange, likes, viewsTotal}
+    mostWatchedRecent: null,      // {title, videoId, viewsInRange, likes, viewsTotal}
+    subscribedSources:[],         // Local JSON extras (traffic sources)
+    discoverySources:[]
   };
 
   const localGeoByCountry = new Map();
@@ -806,6 +808,8 @@
       analytics.overview = ov;
       analytics.countries = cs.sort((a,b)=>b.value-a.value);
       analytics.timeseries = ts;
+      analytics.subscribedSources = [];
+      analytics.discoverySources = [];
 
       // Load top videos extras (likes are total in backend)
       await loadTopAllTime();
@@ -872,9 +876,8 @@
     return applyDetail({ code, name: fallbackName, cities: mockCities(code) });
   }
 
-  function useMockData(){
-    analytics.overview = { views: 123456, watchTimeHours: 789.3, newSubscribers: 420, estRevenue: 321.45 };
-    analytics.countries = [
+  function createMockExporterPayload(){
+    const geoCountries = [
       { countryCode:'US', countryName:'United States of America', value: 48000 },
       { countryCode:'GB', countryName:'United Kingdom', value: 22000 },
       { countryCode:'IN', countryName:'India', value: 18000 },
@@ -886,19 +889,87 @@
       { countryCode:'BR', countryName:'Brazil', value: 5000 },
       { countryCode:'JP', countryName:'Japan', value: 4400 }
     ];
-    const today = new Date(); const arr=[];
-    for(let i=27;i>=0;i--){ const d=new Date(today); d.setDate(d.getDate()-i); arr.push({ date: d.toISOString().slice(0,10), value: 2000+Math.round(1200*Math.sin((i/28)*Math.PI*2)+Math.random()*200) }); }
-    analytics.timeseries = arr;
 
-    // Mock top videos
-    analytics.topAllTime = [
-      { label:'Mock Video A', value: 120000, id:'A' },
-      { label:'Mock Video B', value: 90000, id:'B' },
-      { label:'Mock Video C', value: 70000, id:'C' },
-      { label:'Mock Video D', value: 65000, id:'D' },
-      { label:'Mock Video E', value: 50000, id:'E' },
+    const geoCities = {};
+    geoCountries.forEach(country=>{
+      geoCities[country.countryCode] = mockCities(country.countryCode).map(city=>({ city: city.city, value: city.value }));
+    });
+
+    const today = new Date();
+    const timeseriesDetailed = [];
+    for(let i=27;i>=0;i--){
+      const d = new Date(today);
+      d.setDate(d.getDate()-i);
+      const views = 2000 + Math.round(1200*Math.sin((i/28)*Math.PI*2) + Math.random()*200);
+      const watchTimeHours = Number((views * 0.05).toFixed(2));
+      const subscribers = Math.max(0, Math.round(views / 500 + (Math.random()*6-3)));
+      timeseriesDetailed.push({
+        date: d.toISOString().slice(0,10),
+        views,
+        watchTimeHours,
+        subscribers
+      });
+    }
+
+    const topAllTimeRaw = [
+      { title:'Mock Video A', viewsTotal: 120000, viewsInRange: 18000, videoId:'A', likes: 2500 },
+      { title:'Mock Video B', viewsTotal: 90000, viewsInRange: 15000, videoId:'B', likes: 2100 },
+      { title:'Mock Video C', viewsTotal: 70000, viewsInRange: 13000, videoId:'C', likes: 1800 },
+      { title:'Mock Video D', viewsTotal: 65000, viewsInRange: 11000, videoId:'D', likes: 1600 },
+      { title:'Mock Video E', viewsTotal: 50000, viewsInRange: 9000, videoId:'E', likes: 1200 }
     ];
-    analytics.mostWatchedRecent = { title:'Mock Video A', videoId:'A', viewsInRange:18000, likes:2500, viewsTotal:120000 };
+
+    const mostWatchedRecent = {
+      title: topAllTimeRaw[0].title,
+      videoId: topAllTimeRaw[0].videoId,
+      viewsInRange: topAllTimeRaw[0].viewsInRange,
+      likes: topAllTimeRaw[0].likes,
+      viewsTotal: topAllTimeRaw[0].viewsTotal
+    };
+
+    const totalViews = geoCountries.reduce((sum,c)=>sum + (Number(c.value)||0), 0);
+
+    return {
+      channel: { title: 'Mock Channel Operations' },
+      overview: {
+        views: totalViews,
+        watchTimeHours: Number((totalViews * 0.05).toFixed(2)),
+        newSubscribers: 420,
+        estRevenue: 321.45,
+        videos: topAllTimeRaw.length
+      },
+      timeseriesDetailed,
+      geo: { countries: geoCountries, cities: geoCities },
+      topAllTime: topAllTimeRaw,
+      mostWatchedRecent,
+      subscribed: [
+        { label:'Subscribers', value: 72000 },
+        { label:'Notifications', value: 18000 },
+        { label:'Channel Page', value: 12000 }
+      ],
+      discovery: [
+        { label:'Browse Features', value: 45000 },
+        { label:'Suggested Videos', value: 38000 },
+        { label:'YouTube Search', value: 25000 }
+      ]
+    };
+  }
+
+  function useMockData(){
+    const payload = createMockExporterPayload();
+    const agg = aggregateFromPublicJSON(payload);
+    channelTitle = payload?.channel?.title || 'MOCK CHANNEL';
+    document.title = `WOPR // ${channelTitle}`;
+
+    analytics.overview = agg.overview;
+    analytics.timeseries = agg.ts;
+    analytics.countries = agg.countries || [];
+    analytics.countryDetail = { code:null, name:'', cities:[] };
+    analytics.topAllTime = agg.topVideos;
+    analytics.mostWatchedRecent = agg.recent;
+    analytics.subscribedSources = Array.isArray(agg.subscribed) ? agg.subscribed : [];
+    analytics.discoverySources = Array.isArray(agg.discovery) ? agg.discovery : [];
+    viewMode = analytics.countries.length ? 'GEO' : 'TOP';
   }
 
   function mockCities(code){
@@ -1051,9 +1122,28 @@
   function humanLabel(s){ return (s||'').replace(/\s+/g,' ').trim(); }
 
   function aggregateFromPublicJSON(payload){
+    const safePayload = payload && typeof payload === 'object' ? payload : {};
+    const uploads = Array.isArray(safePayload.uploads)? safePayload.uploads : [];
+    const rawOverview = (safePayload.overview && typeof safePayload.overview === 'object') ? safePayload.overview : null;
+    const rawTopAllTime = Array.isArray(safePayload.topAllTime) ? safePayload.topAllTime : [];
+    const rawMostWatched = safePayload.mostWatchedRecent && typeof safePayload.mostWatchedRecent === 'object'
+      ? safePayload.mostWatchedRecent
+      : null;
+    const rawSubscribed = Array.isArray(safePayload.subscribed) ? safePayload.subscribed : [];
+    const rawDiscovery = Array.isArray(safePayload.discovery) ? safePayload.discovery : [];
+
     localGeoByCountry.clear();
-    const uploads = Array.isArray(payload.uploads)? payload.uploads : [];
-    const safe = uploads.map(u=>({
+
+    const firstNumber = (...candidates) => {
+      for(const candidate of candidates){
+        if(candidate === undefined || candidate === null) continue;
+        const num = Number(candidate);
+        if(!Number.isNaN(num)) return num;
+      }
+      return 0;
+    };
+
+    const safeUploads = uploads.map(u=>({
       id: u.id,
       title: humanLabel(u.title),
       publishedAt: u.publishedAt,
@@ -1064,36 +1154,96 @@
       }
     }));
 
-    const overview = safe.reduce((acc,u)=>{
-      acc.views += u.stats.views; acc.videos += 1; return acc;
-    }, { views:0, videos:0, watchTimeHours: 0, newSubscribers: 0, estRevenue: 0 });
+    const overview = {
+      views: firstNumber(rawOverview?.views, rawOverview?.viewsTotal, rawOverview?.totalViews),
+      watchTimeHours: firstNumber(
+        rawOverview?.watchTimeHours,
+        rawOverview?.watchTime,
+        rawOverview?.watchTimeMinutes ? Number(rawOverview.watchTimeMinutes)/60 : undefined
+      ),
+      newSubscribers: firstNumber(rawOverview?.newSubscribers, rawOverview?.subscribers, rawOverview?.netSubscribers),
+      estRevenue: firstNumber(rawOverview?.estRevenue, rawOverview?.estimatedRevenue, rawOverview?.revenue)
+    };
 
-    const topVideos = [...safe]
-      .sort((a,b)=>b.stats.views-a.stats.views)
-      .slice(0,5)
-      .map(v=>({ label: v.title.slice(0,22), value: v.stats.views, id: v.id }));
+    if(!rawOverview){
+      const aggregated = safeUploads.reduce((acc,u)=>{
+        acc.views += u.stats.views;
+        acc.videos += 1;
+        return acc;
+      }, { views:0, videos:0 });
+      overview.views = firstNumber(overview.views, aggregated.views);
+      overview.watchTimeHours = firstNumber(overview.watchTimeHours);
+      overview.newSubscribers = firstNumber(overview.newSubscribers);
+      overview.estRevenue = firstNumber(overview.estRevenue);
+      overview.videos = aggregated.videos;
+    } else {
+      overview.videos = firstNumber(rawOverview?.videos, rawOverview?.videoCount, rawOverview?.totalVideos);
+    }
 
-    const recent = [...safe]
-      .sort((a,b)=> new Date(b.publishedAt)-new Date(a.publishedAt))
-      .slice(0,1)
-      .map(v=>({ title: v.title, videoId: v.id, viewsInRange: v.stats.views, likes: v.stats.likes, viewsTotal: v.stats.views }))[0] || null;
+    const determineVideoCount = () => {
+      if(typeof overview.videos === 'number' && overview.videos>0) return overview.videos;
+      if(rawOverview && typeof rawOverview.videos === 'string' && rawOverview.videos.trim()){
+        const parsed = Number(rawOverview.videos);
+        if(!Number.isNaN(parsed) && parsed>0) return parsed;
+      }
+      if(safeUploads.length) return safeUploads.length;
+      if(rawTopAllTime.length) return rawTopAllTime.length;
+      return 0;
+    };
 
-    const byDay = new Map();
-    safe.forEach(v=>{
-      const day=(v.publishedAt||'').slice(0,10);
-      if(!day) return;
-      byDay.set(day, (byDay.get(day)||0) + (v.stats.views||0));
-    });
-    const ts = [...byDay.keys()].sort().map(d=>({ date:d, value: byDay.get(d) }));
+    const normalizeTimeseriesRow = (row) => {
+      if(!row) return null;
+      if(Array.isArray(row)){
+        const date = (row[0]||'').toString().slice(0,10);
+        const value = firstNumber(row[1], row.value, row.views);
+        if(!date) return null;
+        return { date, value };
+      }
+      if(typeof row === 'object'){
+        const date = (row.date || row.day || row.startDate || row.endDate || '').toString().slice(0,10);
+        const value = firstNumber(row.value, row.views, row.metrics?.views);
+        if(!date) return null;
+        return { date, value };
+      }
+      return null;
+    };
 
-    const geoCountriesRaw = Array.isArray(payload?.geo?.countries) ? payload.geo.countries : [];
-    const geoCitiesRaw = payload?.geo?.cities && typeof payload.geo.cities === 'object' ? payload.geo.cities : {};
+    const rawTimeseriesDetailed = Array.isArray(safePayload.timeseriesDetailed) ? safePayload.timeseriesDetailed : [];
+    const rawTimeseries = Array.isArray(safePayload.timeseries) ? safePayload.timeseries : [];
+
+    let ts = [];
+    if(rawTimeseriesDetailed.length){
+      ts = rawTimeseriesDetailed.map((row)=>{
+        if(row && typeof row === 'object'){
+          const date = (row.date || row.day || '').toString().slice(0,10);
+          const value = firstNumber(row.views, row.value, row.metrics?.views);
+          if(date) return { date, value };
+        }
+        return normalizeTimeseriesRow(row);
+      }).filter(Boolean);
+    }
+    if(!ts.length && rawTimeseries.length){
+      ts = rawTimeseries.map(normalizeTimeseriesRow).filter(Boolean);
+    }
+    if(!ts.length && safeUploads.length){
+      const byDay = new Map();
+      safeUploads.forEach(v=>{
+        const day=(v.publishedAt||'').slice(0,10);
+        if(!day) return;
+        byDay.set(day, (byDay.get(day)||0) + (v.stats.views||0));
+      });
+      ts = [...byDay.entries()].sort((a,b)=>a[0].localeCompare(b[0])).map(([date,value])=>({ date, value }));
+    }
+    ts.sort((a,b)=> a.date.localeCompare(b.date));
+
+    const geoCountriesRaw = Array.isArray(safePayload?.geo?.countries) ? safePayload.geo.countries : [];
+    const geoCitiesRaw = safePayload?.geo?.cities && typeof safePayload.geo.cities === 'object' ? safePayload.geo.cities : {};
 
     const countries = geoCountriesRaw
       .map(c=>({
         countryCode: (c.countryCode || '').toUpperCase(),
         countryName: humanLabel(c.countryName || c.countryCode || ''),
-        value: Number(c.value||0)
+        value: firstNumber(c.value, c.views, c.count)
       }))
       .filter(c=>c.countryCode && !Number.isNaN(c.value))
       .sort((a,b)=>b.value-a.value);
@@ -1104,7 +1254,7 @@
       const key = c.countryCode;
       const rawCities = Array.isArray(geoCitiesRaw?.[key]) ? geoCitiesRaw[key] : [];
       const cities = rawCities
-        .map(city=>({ city: humanLabel(city.city || ''), value: Number(city.value||0) }))
+        .map(city=>({ city: humanLabel(city.city || city.name || ''), value: firstNumber(city.value, city.views, city.count) }))
         .filter(city=>city.city && !Number.isNaN(city.value))
         .sort((a,b)=>b.value-a.value);
       localGeoByCountry.set(key, { name: c.countryName, cities });
@@ -1114,7 +1264,7 @@
       if(localGeoByCountry.has(code)) return;
       const rawCities = Array.isArray(list) ? list : [];
       const cities = rawCities
-        .map(city=>({ city: humanLabel(city.city || ''), value: Number(city.value||0) }))
+        .map(city=>({ city: humanLabel(city.city || city.name || ''), value: firstNumber(city.value, city.views, city.count) }))
         .filter(city=>city.city && !Number.isNaN(city.value))
         .sort((a,b)=>b.value-a.value);
       if(!cities.length) return;
@@ -1123,16 +1273,53 @@
       localGeoByCountry.set(code, { name, cities });
     });
 
-    return { overview, topVideos, recent, ts, countries };
-  }
+    const mapTopVideo = (entry) => {
+      const title = humanLabel(entry?.title || entry?.label || '');
+      return {
+        label: title ? title.slice(0,22) : '(untitled)',
+        value: firstNumber(entry?.viewsInRange, entry?.viewsTotal, entry?.views, entry?.value),
+        id: entry?.videoId || entry?.id || null
+      };
+    };
 
-  function applyPublicJSON(payload){
+    const topVideos = rawTopAllTime.map(mapTopVideo).filter(v=>v.value>0 || v.id || v.label);
+
+    const recent = rawMostWatched ? {
+      title: humanLabel(rawMostWatched.title || rawMostWatched.videoTitle || ''),
+      videoId: rawMostWatched.videoId || rawMostWatched.id || null,
+      viewsInRange: firstNumber(rawMostWatched.viewsInRange, rawMostWatched.viewsRecent, rawMostWatched.views),
+      likes: firstNumber(rawMostWatched.likes, rawMostWatched.likesInRange, rawMostWatched.likeCount),
+      viewsTotal: firstNumber(rawMostWatched.viewsTotal, rawMostWatched.totalViews, rawMostWatched.views)
+    } : null;
+
+    const normalizeSource = (entry) => {
+      const label = humanLabel(entry?.label || entry?.title || entry?.name || '');
+      const value = firstNumber(entry?.value, entry?.views, entry?.count);
+      if(!label) return null;
+      return { label, value };
+    };
+
+    const subscribed = rawSubscribed.map(normalizeSource).filter(Boolean);
+    const discovery = rawDiscovery.map(normalizeSource).filter(Boolean);
+
+    return {
+      overview,
+      topVideos,
+      recent,
+      ts,
+      countries,
+      subscribed,
+      discovery,
+      videoCount: determineVideoCount()
+    };
+  }
+  function applyPublicJSON(payload, aggregated){
     dataMode = 'LOCAL';
     connectionStatus.textContent = 'LOCAL JSON';
     channelTitle = payload?.channel?.title || null;
     if(channelTitle){ document.title = `WOPR // ${channelTitle}`; }
 
-    const agg = aggregateFromPublicJSON(payload);
+    const agg = aggregated || aggregateFromPublicJSON(payload);
     analytics.overview = agg.overview;
     analytics.timeseries = agg.ts;
     analytics.countries = agg.countries || [];
@@ -1141,9 +1328,12 @@
     // In LOCAL mode, repurpose panels to Top/Recent if no geo data is present
     analytics.topAllTime = agg.topVideos;
     analytics.mostWatchedRecent = agg.recent;
+    analytics.subscribedSources = Array.isArray(agg.subscribed) ? agg.subscribed : [];
+    analytics.discoverySources = Array.isArray(agg.discovery) ? agg.discovery : [];
     viewMode = analytics.countries.length ? 'GEO' : 'TOP';
 
     drawAll();
+    return agg;
   }
 
   jsonInput?.addEventListener('change', async (e)=>{
@@ -1151,9 +1341,23 @@
     try{
       const text = await f.text();
       const payload = JSON.parse(text);
-      if(!payload || !Array.isArray(payload.uploads)) throw new Error('Invalid JSON: missing uploads[]');
-      applyPublicJSON(payload);
-      printLine(`IMPORTED ${payload.uploads.length} VIDEOS${channelTitle? ' — '+channelTitle: ''}`);
+      const hasNewRoots = payload && typeof payload === 'object' && (
+        (payload.channel && typeof payload.channel === 'object') ||
+        (payload.overview && typeof payload.overview === 'object') ||
+        Array.isArray(payload.timeseries) ||
+        Array.isArray(payload.timeseriesDetailed) ||
+        (payload.geo && (Array.isArray(payload.geo?.countries) || payload.geo?.cities)) ||
+        Array.isArray(payload.topAllTime) ||
+        Array.isArray(payload.subscribed) ||
+        Array.isArray(payload.discovery)
+      );
+      if(!Array.isArray(payload.uploads) && !hasNewRoots){
+        throw new Error('Invalid JSON: expected uploads[] or analytics fields');
+      }
+      const agg = applyPublicJSON(payload);
+      const count = agg?.videoCount || (Array.isArray(payload.uploads) ? payload.uploads.length : 0);
+      const label = count ? `${count} ${count===1?'VIDEO':'VIDEOS'}` : 'DATASET';
+      printLine(`IMPORTED ${label}${channelTitle? ' — '+channelTitle: ''}`);
     }catch(err){
       printLine('ERROR: '+(err?.message||String(err)), 'error');
     }


### PR DESCRIPTION
## Summary
- relax the local JSON importer to accept the new exporter payload roots
- rewrite aggregateFromPublicJSON to map the new overview, timeseries, geo, and top video fields into analytics state
- refresh the mock data generator to emit exporter-shaped data so offline mode still works

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dc14f486f48325822f5c6e447665f5